### PR TITLE
Add challenge that uses the Network tab

### DIFF
--- a/challenges/hard/jellyfish-password.json
+++ b/challenges/hard/jellyfish-password.json
@@ -1,0 +1,3 @@
+{
+    "password": "wahoo"
+}

--- a/challenges/hard/jellyfish.html
+++ b/challenges/hard/jellyfish.html
@@ -1,0 +1,43 @@
+<!doctype html>
+
+<html>
+  <head>
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <title>Hacker Challenge</title>
+    <link rel="stylesheet" href="/style.css">
+  </head>
+
+  <body>
+    <div class="help-section">
+      <div class="help-blurb hidden">
+        <p>Right click in the browser window and click the last option, <strong>"Inspect"</strong>.</p>
+        <p>Open the <strong>"Network"</strong> tab and find the <code>jellyfish-password.json</code>.</p>
+        <p>Click on <code>jellyfish-password.json</code> and use the "Preview" tab to inspect the response.</p>
+      </div>
+      <a class="help-button closed">?</a>
+    </div>
+
+    <div class="main">
+      <section>
+        <h1>
+          <a href="/">Hacker Challenge</a>
+        </h1>
+        <h2>Challenge #10: Fetch the password from the "Network" tab</h2>
+        <div class="challenge">
+          <div class="form">
+            <input class="network-password" type="text" placeholder="Enter password" />
+            <button class="network-btn" type="submit">Submit</button>
+          </div>
+          <div class="error hidden">INCORRECT PASSWORD</div>
+        </div>
+      </div>
+    </div>
+
+    <script src="/scripts/global.js"></script>
+    <script src="/scripts/normal.js"></script>
+    <script>
+        fetch("./jellyfish-password.json", { method: 'GET'})
+    </script>
+  </body>
+</html>

--- a/challenges/hard/jellyfish.html
+++ b/challenges/hard/jellyfish.html
@@ -13,7 +13,7 @@
       <div class="help-blurb hidden">
         <p>Right click in the browser window and click the last option, <strong>"Inspect"</strong>.</p>
         <p>Open the <strong>"Network"</strong> tab and find the <code>jellyfish-password.json</code>. If you don't see <code>jellyfish-password.json</code>, try refreshing your page.</p>
-        <p>Click on <code>jellyfish-password.json</code> and use the "Preview" tab to inspect the response.</p>
+        <p>Click on <code>jellyfish-password.json</code> and use the <strong>"Preview"</strong> tab to inspect the response.</p>
       </div>
       <a class="help-button closed">?</a>
     </div>

--- a/challenges/hard/jellyfish.html
+++ b/challenges/hard/jellyfish.html
@@ -12,7 +12,7 @@
     <div class="help-section">
       <div class="help-blurb hidden">
         <p>Right click in the browser window and click the last option, <strong>"Inspect"</strong>.</p>
-        <p>Open the <strong>"Network"</strong> tab and find the <code>jellyfish-password.json</code>.</p>
+        <p>Open the <strong>"Network"</strong> tab and find the <code>jellyfish-password.json</code>. If you don't see <code>jellyfish-password.json</code>, try refreshing your page.</p>
         <p>Click on <code>jellyfish-password.json</code> and use the "Preview" tab to inspect the response.</p>
       </div>
       <a class="help-button closed">?</a>

--- a/challenges/normal/jellyfish-password.json
+++ b/challenges/normal/jellyfish-password.json
@@ -1,0 +1,3 @@
+{
+    "password": "wahoo"
+}

--- a/challenges/normal/jellyfish.html
+++ b/challenges/normal/jellyfish.html
@@ -1,0 +1,43 @@
+<!doctype html>
+
+<html>
+  <head>
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <title>Hacker Challenge</title>
+    <link rel="stylesheet" href="/style.css">
+  </head>
+
+  <body>
+    <div class="help-section">
+      <div class="help-blurb hidden">
+        <p>Right click in the browser window and click the last option, <strong>"Inspect"</strong>.</p>
+        <p>Open the <strong>"Network"</strong> tab and find the <code>jellyfish-password.json</code>.</p>
+        <p>Click on <code>jellyfish-password.json</code> and use the "Preview" tab to inspect the response.</p>
+      </div>
+      <a class="help-button closed">?</a>
+    </div>
+
+    <div class="main">
+      <section>
+        <h1>
+          <a href="/">Hacker Challenge</a>
+        </h1>
+        <h2>Challenge #10: Fetch the password from the "Network" tab</h2>
+        <div class="challenge">
+          <div class="form">
+            <input class="network-password" type="text" placeholder="Enter password" />
+            <button class="network-btn" type="submit">Submit</button>
+          </div>
+          <div class="error hidden">INCORRECT PASSWORD</div>
+        </div>
+      </div>
+    </div>
+
+    <script src="/scripts/global.js"></script>
+    <script src="/scripts/normal.js"></script>
+    <script>
+        fetch("./jellyfish-password.json", { method: 'GET'})
+    </script>
+  </body>
+</html>

--- a/challenges/normal/jellyfish.html
+++ b/challenges/normal/jellyfish.html
@@ -13,7 +13,7 @@
       <div class="help-blurb hidden">
         <p>Right click in the browser window and click the last option, <strong>"Inspect"</strong>.</p>
         <p>Open the <strong>"Network"</strong> tab and find the <code>jellyfish-password.json</code>. If you don't see <code>jellyfish-password.json</code>, try refreshing your page.</p>
-        <p>Click on <code>jellyfish-password.json</code> and use the "Preview" tab to inspect the response.</p>
+        <p>Click on <code>jellyfish-password.json</code> and use the <strong>"Preview"</strong> tab to inspect the response.</p>
       </div>
       <a class="help-button closed">?</a>
     </div>

--- a/challenges/normal/jellyfish.html
+++ b/challenges/normal/jellyfish.html
@@ -12,7 +12,7 @@
     <div class="help-section">
       <div class="help-blurb hidden">
         <p>Right click in the browser window and click the last option, <strong>"Inspect"</strong>.</p>
-        <p>Open the <strong>"Network"</strong> tab and find the <code>jellyfish-password.json</code>.</p>
+        <p>Open the <strong>"Network"</strong> tab and find the <code>jellyfish-password.json</code>. If you don't see <code>jellyfish-password.json</code>, try refreshing your page.</p>
         <p>Click on <code>jellyfish-password.json</code> and use the "Preview" tab to inspect the response.</p>
       </div>
       <a class="help-button closed">?</a>

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -22,17 +22,17 @@ window.addEventListener("DOMContentLoaded", (event) => {
 
   //
   // ---------------------------------------------------------
-  // Styles challenge
+  // Network tab challenge
   // ---------------------------------------------------------
   //
 
-  const stylesPasswordSubmitBtn = document.querySelector("button.styles-btn");
-  const stylesPasswordField = document.querySelector("input.styles-password");
-  const stylesPassword = "hocus pocus"
+  const networkPasswordSubmitBtn = document.querySelector("button.network-btn");
+  const networkPasswordField = document.querySelector("input.network-password");
+  const networkPassword = "wahoo"
 
-  if (stylesPasswordSubmitBtn) {
-    stylesPasswordSubmitBtn.addEventListener("click", event => {
-      if (stylesPasswordField.value == stylesPassword) {
+  if (networkPasswordSubmitBtn) {
+    networkPasswordSubmitBtn.addEventListener("click", event => {
+      if (networkPasswordField.value == networkPassword) {
         window.location.href = "/complete.html";
       } else {
         throwError();

--- a/scripts/hard.js
+++ b/scripts/hard.js
@@ -149,3 +149,23 @@ window.addEventListener("DOMContentLoaded", (event) => {
     });
   };
 });
+
+  //
+  // ---------------------------------------------------------
+  // Styles challenge
+  // ---------------------------------------------------------
+  //
+
+  const stylesPasswordSubmitBtn = document.querySelector("button.styles-btn");
+  const stylesPasswordField = document.querySelector("input.styles-password");
+  const stylesPassword = "hocus pocus"
+
+  if (stylesPasswordSubmitBtn) {
+    stylesPasswordSubmitBtn.addEventListener("click", event => {
+      if (stylesPasswordField.value == stylesPassword) {
+        window.location.href = "/challenges/hard/jellyfish.html";
+      } else {
+        throwError();
+      };
+    });
+  };

--- a/scripts/normal.js
+++ b/scripts/normal.js
@@ -110,3 +110,23 @@ window.addEventListener("DOMContentLoaded", (event) => {
     });
   };
 });
+
+  //
+  // ---------------------------------------------------------
+  // Styles challenge
+  // ---------------------------------------------------------
+  //
+
+  const stylesPasswordSubmitBtn = document.querySelector("button.styles-btn");
+  const stylesPasswordField = document.querySelector("input.styles-password");
+  const stylesPassword = "hocus pocus"
+
+  if (stylesPasswordSubmitBtn) {
+    stylesPasswordSubmitBtn.addEventListener("click", event => {
+      if (stylesPasswordField.value == stylesPassword) {
+        window.location.href = "/challenges/normal/jellyfish.html";
+      } else {
+        throwError();
+      };
+    });
+  };


### PR DESCRIPTION
Hello! :wave:

This PR adds a challenge that uses the Network tab. 🦑 🐟 
It makes a request to `jellyfish-password.json` which contains the password.

Closes #5 

<img width="1120" alt="Screen Shot 2022-02-12 at 21 36 32" src="https://user-images.githubusercontent.com/72365100/153740379-a2cd7199-decf-4284-a765-a8a09b8d66a8.png">

<img width="1263" alt="Screen Shot 2022-02-12 at 21 36 55" src="https://user-images.githubusercontent.com/72365100/153740389-a2ac6f8b-e00e-418b-90a2-be0e0fb2b735.png">

